### PR TITLE
refactor: swap escodegen with astring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
     "name": "rollup-plugin-jsx-remove-attributes",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "rollup-plugin-jsx-remove-attributes",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "license": "SEE LICENSE IN LICENSE.txt",
             "devDependencies": {
                 "@biomejs/biome": "1.7.3",
                 "@types/acorn": "6.0.0",
-                "@types/escodegen": "0.0.7",
                 "@types/node": "22.10.2",
                 "@types/rollup": "0.54.0",
                 "rollup": "4.29.1",
@@ -22,7 +21,7 @@
             },
             "peerDependencies": {
                 "@rollup/pluginutils": ">=5.1",
-                "escodegen": ">=2.1",
+                "astring": ">=1.9.0",
                 "estree-walker": ">=3.0",
                 "vite": ">=5.2"
             }
@@ -867,12 +866,6 @@
                 "acorn": "*"
             }
         },
-        "node_modules/@types/escodegen": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/@types/escodegen/-/escodegen-0.0.7.tgz",
-            "integrity": "sha512-46oENdSRNEJXCNrPJoC3vRolZJpfeEm7yvATkd2bCncKFG0PUEyfBCaoacfpcXH4Y5RRuqdVj3J7TI+wwn2SbQ==",
-            "dev": true
-        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -907,6 +900,16 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/astring": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+            "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+            "license": "MIT",
+            "peer": true,
+            "bin": {
+                "astring": "bin/astring"
             }
         },
         "node_modules/esbuild": {
@@ -949,49 +952,6 @@
                 "@esbuild/win32-x64": "0.25.0"
             }
         },
-        "node_modules/escodegen": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-            "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
-            "peer": true,
-            "dependencies": {
-                "esprima": "^4.0.1",
-                "estraverse": "^5.2.0",
-                "esutils": "^2.0.2"
-            },
-            "bin": {
-                "escodegen": "bin/escodegen.js",
-                "esgenerate": "bin/esgenerate.js"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "optionalDependencies": {
-                "source-map": "~0.6.1"
-            }
-        },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "peer": true,
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/estraverse": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "peer": true,
-            "engines": {
-                "node": ">=4.0"
-            }
-        },
         "node_modules/estree-walker": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -999,15 +959,6 @@
             "peer": true,
             "dependencies": {
                 "@types/estree": "^1.0.0"
-            }
-        },
-        "node_modules/esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/fsevents": {
@@ -1123,16 +1074,6 @@
                 "@rollup/rollup-win32-ia32-msvc": "4.29.1",
                 "@rollup/rollup-win32-x64-msvc": "4.29.1",
                 "fsevents": "~2.3.2"
-            }
-        },
-        "node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "optional": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "devDependencies": {
         "@biomejs/biome": "1.7.3",
         "@types/acorn": "6.0.0",
-        "@types/escodegen": "0.0.7",
         "@types/node": "22.10.2",
         "@types/rollup": "0.54.0",
         "rollup": "4.29.1",
@@ -47,7 +46,7 @@
     },
     "peerDependencies": {
         "@rollup/pluginutils": ">=5.1",
-        "escodegen": ">=2.1",
+        "astring": ">=1.9.0",
         "estree-walker": ">=3.0",
         "vite": ">=5.2"
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { createFilter } from "@rollup/pluginutils";
 import type { FilterPattern } from "@rollup/pluginutils";
-import { generate } from "escodegen";
+import { generate } from "astring";
 import type {
 	Identifier,
 	Node,


### PR DESCRIPTION
**Related Issue:** N/A

## Summary

`escodegen` doesn't appear to be [actively maintained](https://github.com/estools/escodegen/activity), and some setups depend on fixes that are unlikely to land anytime soon (see https://github.com/Esri/calcite-design-system/issues/6760#issuecomment-2660543976).

This replaces it with [`astring`](https://github.com/davidbonnet/astring), which provides equivalent functionality and seems [more active](https://github.com/davidbonnet/astring/activity).

Curious if there’s a preferred test approach for this. I ran a quick check with a simple setup, which looked fine, but happy to adjust if I missed anything.