### PR TITLE
Fix for elements with spread attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## version 3.1.1 - 2025-07-25
+
+### fixed
+-- fixed to support elements that contain JSX spread attributes
+
 ## version 3.1.0 - 2025-07-16
 
 ### changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "rollup-plugin-jsx-remove-attributes",
-    "version": "3.0.0",
+    "version": "3.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "rollup-plugin-jsx-remove-attributes",
-            "version": "3.0.0",
+            "version": "3.1.1",
             "license": "SEE LICENSE IN LICENSE.txt",
             "dependencies": {
                 "source-map": "0.7.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rollup-plugin-jsx-remove-attributes",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "description": "rollup &amp; vite plugin to remove jsx attributes",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function isJSXCallExpression(jsx: unknown): jsx is JSXCallExpression {
 	return (
 		ce?.type === "CallExpression" &&
 		ce?.callee?.type === "Identifier" &&
-		["jsx", "jsxs"].includes(ce?.callee?.name)
+		["jsx", "jsxs", "__spreadValues"].includes(ce?.callee?.name)
 	);
 }
 

--- a/test/fixtures/preact/PreactFormAST.ts
+++ b/test/fixtures/preact/PreactFormAST.ts
@@ -643,6 +643,57 @@ export default {
 																							},
 																							{
 																								type: "CallExpression",
+																								start: 830,
+																								end: 860,
+																								optional: false,
+																								_rollupAnnotations: [
+																									{
+																										end: 829,
+																										start: 815,
+																										type: "pure",
+																									},
+																								],
+																								callee: {
+																									type: "Identifier",
+																									start: 830,
+																									end: 844,
+																									name: "__spreadValues",
+																								},
+																								arguments: [
+																									{
+																										type: "ObjectExpression",
+																										start: 845,
+																										end: 859,
+																										properties: [
+																											{
+																												type: "Property",
+																												start: 846,
+																												end: 858,
+																												method: false,
+																												shorthand: false,
+																												computed: false,
+																												key: {
+																													type: "Literal",
+																													start: 846,
+																													end: 857,
+																													value: "data-testid",
+																													raw: '"data-testid"',
+																												},
+																												value: {
+																													type: "Literal",
+																													start: 858,
+																													end: 864,
+																													value: "test",
+																													raw: '"test"',
+																												},
+																												kind: "init",
+																											},
+																										],
+																									},
+																								],
+																							},
+																							{
+																								type: "CallExpression",
 																								start: 861,
 																								end: 1140,
 																								optional: false,


### PR DESCRIPTION
Any element with a spread attribute, for example:
`<div data-testid="my-div" {...props} />`
is given the `node.callee.name` of "__spreadValues" instead of "jsx" or "jsxs".

This has been my finding in Preact at least. Not sure if it's the case for React as well.

I've added a fix as well as a new element in the test fixtures along with changelog and version updates.