### PR TITLE
Support automatic runtime injections by @babel/plugin-transform-react-jsx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function isJSXCallExpression(jsx: unknown): jsx is JSXCallExpression {
 	return (
 		ce?.type === "CallExpression" &&
 		ce?.callee?.type === "Identifier" &&
-		["jsx", "jsxs", "__spreadValues"].includes(ce?.callee?.name)
+		["jsx", "jsxs", "_jsx", "_jsxs",  "__spreadValues"].includes(ce?.callee?.name)
 	);
 }
 


### PR DESCRIPTION
This PR adds new function names `_jsx` and `_jsxs` to be considered as jsx runtime functions as described in `babel-plugin-transform-react-jsx` documentation starting from version v7.9.0: https://babeljs.io/docs/babel-plugin-transform-react-jsx#react-automatic-runtime .

Related issue https://github.com/jacobbogers/rollup-plugin-jsx-remove-attributes/issues/9